### PR TITLE
chore(git): attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# -*- mode: gitattributes; -*-
+conf.d linguist-language=Nginx
+*.conf linguist-language=Nginx


### PR DESCRIPTION
enable gitattributes so syntax highlighting is applied to configuration files.

alt, a modeline to achieve the same effect:

~~~nginx
# -*- nginx -*-
user  nginx;
worker_processes  auto;

error_log  /var/log/nginx/error.log notice;
pid        /var/run/nginx.pid;
~~~